### PR TITLE
Repaired old script

### DIFF
--- a/ImageFap Scraper/IFScraper.py
+++ b/ImageFap Scraper/IFScraper.py
@@ -6,7 +6,7 @@ import time
 import re
 from lib import pyperclip
 
-PARANOID_SLEEP = 6
+PARANOID_SLEEP = 2
 
 def zeroPad(num, maxnum):
     """Return the correct number or preceeding zeros to make the numbers sort cleanly in a filesystem
@@ -20,7 +20,7 @@ def zeroPad(num, maxnum):
     zeros = max_digits - num_digits
     for i in range(0, zeros):
         prefix = prefix + '0'
-    return prefix
+    return str(prefix) + str(num)
 
 
 def FetchPageText( pageurl ):
@@ -88,7 +88,7 @@ def GetGalleryIndex( ctx ):
         new_url = new_url.split('\"')[0]
         new_url = 'http://www.imagefap.com' + new_url
         new_url = new_url.replace('&amp;', '&')
-        print('url=[' + new_url +']') 
+        #print('url=[' + new_url +']') 
         fetch_ary.append(new_url);
         offset = idx + len(needle)
         idx = html.find(needle, offset)
@@ -112,7 +112,11 @@ def ExtractMetadata( ctx, html ):
         name = html[idx+len(needle):]
         name = name.split('?')[0]
         name = name.split('/')[1]
-        print("name = [" + name + "]\n")
+        name = urllib2.unquote(name)
+        bad_winchars = {'*':'', '.':'', '"':'', '/':'', '\\':'', '[':'(', ']':'(', ':':'', ';':'', '|':'-', '=':'-', ',':'', '!':''}
+        for o_char,n_char in bad_winchars.iteritems():
+            name = name.replace(o_char, n_char)
+        #print("name = [" + name + "]\n")
 
     # Uploader
     needle = '<b><font size="3" color="#CC0000">Uploaded by '
@@ -123,7 +127,7 @@ def ExtractMetadata( ctx, html ):
     else:
         uploader = html[idx+len(needle):]
         uploader = uploader.split('</font>')[0]
-        print("uploader = [" + uploader + "]\n")
+        #print("uploader = [" + uploader + "]\n")
 
     # Date
     ctx['download_date'] = time.strftime("%c")

--- a/ImageFap Scraper/IFScraper.py
+++ b/ImageFap Scraper/IFScraper.py
@@ -6,7 +6,7 @@ import time
 import re
 from lib import pyperclip
 
-PARANOID_SLEEP = 2
+PARANOID_SLEEP = 1
 
 def zeroPad(num, maxnum):
     """Return the correct number or preceeding zeros to make the numbers sort cleanly in a filesystem
@@ -135,6 +135,19 @@ def ExtractMetadata( ctx, html ):
     ctx['gallery_uploader'] = uploader
     return ctx
 
+def EmitMetadata( ctx, dname ):
+    """Saves the context metadata about the gallery name/uploader/urls/etc to a log file beginning with three underscores"""
+    preamble = '<html><head><title>ImageFap Scrape Data</title></head>\n<body><pre>\n'
+    postamble = '\n</pre></body></html>\n'
+    fname = dname + '/___ImageFap_Scrape_Info.html'
+    print('Writing log to [' +fname+']')
+    f = open(fname, 'w')
+    f.write(preamble)
+    f.write( str(ctx) )
+    f.write(postamble)
+    f.close()
+    return
+
 def FetchAndSaveImages( ctx ):
     """
     Runs through the array ctx['image_preview_urls'] using each preview url to determine the full res image url. Then downloads and saves the full image.
@@ -143,7 +156,7 @@ def FetchAndSaveImages( ctx ):
     try:
         os.makedirs(foldername)
     except:
-        print "Error, make sure there is no directory with this script"
+        print("Error, make sure there is no directory with this script")
         return 0
     imgnum = 0
     imgcount = ctx['image_count']
@@ -153,12 +166,13 @@ def FetchAndSaveImages( ctx ):
         ctx['image_urls'].append(imgurl)
         orig_fname = imgurl[imgurl.rindex('/')+1:]
         imgname = foldername+'/'+zeroPad(imgnum,imgcount)+'__'+orig_fname
-        print('Preparing to write to [' +imgname+']')
+        print('Saving [' +imgname+']')
         f = open(imgname, 'wb')
         f.write(urllib2.urlopen(imgurl).read())
         f.close()
-        print '\t'+str(imgnum+1)+'/'+str(imgcount)+ ' completed\n'
+        print('\t'+str(imgnum+1)+'/'+str(imgcount)+ ' completed')
         imgnum += 1
+    EmitMetadata(ctx, foldername)
     return ctx
 
 def FindFullGalleryURL( a_url ):
@@ -217,19 +231,17 @@ def main():
         url = raw_input("\nEnter the url: ")
 
     ctx = FindFullGalleryURL( url );
-    print('fetching full gallery at [' + ctx['gallery_index_url'] + ']\n')    
+    print('Fetching full gallery index at [' + ctx['gallery_index_url'] + ']')    
     ctx = GetGalleryIndex( ctx )
 
     print("\n\nThere are "+str(ctx['image_count'])+" pics in the gallery: \""+ ctx['gallery_name']+"\".")
     contnum = 2
     contnum = raw_input("Would you like to download them all? 1=yes 2=no: ")
     if contnum == '1' or contnum == 'y':
-        #ctx = FetchAndSaveMetadata( ctx )
         print('\n')
         ctx = FetchAndSaveImages( ctx )
     else:
         print("Bailing out.\n")
         exit(0)
-
 
 main()

--- a/ImageFap Scraper/IFScraper.py
+++ b/ImageFap Scraper/IFScraper.py
@@ -1,6 +1,44 @@
 import urllib2
 import os
+import time
 from lib import pyperclip
+
+def zeroPad(num):
+    result = ''
+    if num < 0:
+        print("error")
+        exit(-3)
+    elif num < 10:
+        result = '00' + str(num)
+    elif num < 100:
+        result = '0' + str(num)
+    else:
+        result = str(num)
+    return result
+
+def FetchImageURL(pageurl):
+    imgurl = ''
+    hdr= {'Accept':'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+          'User-Agent':'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.110 Safari/537.36'}             
+    req = urllib2.Request(pageurl, "", hdr)
+    response = urllib2.urlopen(req)
+    html = response.read()
+    ##############
+    with open("response.html", "w") as text_file:
+            text_file.write(html)
+            text_file.close()
+    ##############
+    needle = '\"contentUrl\": \"'
+    idx = html.find(needle) 
+    if idx == -1:
+        print('Sorry, cannot parse index. Something must have changed. Bailing out.\n');
+        exit(-2);
+    else:
+        imgurl = html[idx+len(needle):]
+        imgurl = imgurl.split('</script>')[0]
+        imgurl = imgurl.split('\"')[0];
+        print('finalimgurl = [' + imgurl + ']')
+    return imgurl
 
 def PageScrape(pageurl):
     hdr= {'Accept':'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
@@ -8,22 +46,38 @@ def PageScrape(pageurl):
     req = urllib2.Request(pageurl, "", hdr)
     response = urllib2.urlopen(req)
     html = response.read()
-    search = 'Gallery:'
-    for i in range(len(html)-len(search)):
-        if search == html[i:i+len(search)]:
-            foldername = html[i+len(search)-1:]
-            foldername = foldername.split('<')[3].split('>')[1]
-    while foldername[-1]=='.' or foldername[-1]==' ':
-        foldername = foldername[:-1]
-    search = 'original=\"'
-    imgnum = 1
+    ##############
+    with open("response.html", "w") as text_file:
+            text_file.write(html)
+            text_file.close()
+    ##############
+    search = '<b><font size=\"4\" color='
+    idx = html.find(search) 
+    if idx == -1:
+        print('Sorry, cannot parse index. Something must have changed. Bailing out.\n');
+        exit(-2);
+    else:
+        foldername = html[idx:]
+        foldername = foldername.split('</font></b>')[0]
+        foldername = foldername.split('>')[2]        
+        while foldername[-1]=='.' or foldername[-1]==' ':
+            foldername = foldername[:-1]
+    search = 'href=\"/photo'
     imgcount = 0
+    fetch_ary = []
     for i in range(len(html)-len(search)):
         if search == html[i:i+len(search)]:
             imgcount += 1
-    print "\n\nThere are "+str(imgcount)+" pics in the gallery: "+foldername+"."
+            new_url = html[i+6:]
+            new_url = new_url.split('<img style=')[0]
+            new_url = new_url.split('\"')[0]
+            new_url = 'http://www.imagefap.com' + new_url
+            print('url=[' + new_url +']') 
+            fetch_ary.append(new_url);
+    print "\n\nThere are "+str(imgcount)+" pics in the gallery: \""+foldername+"\"."
     contnum = 2
     contnum = raw_input("Would you like to download them all? 1=yes 2=no: ")
+
     foldername = 'Downloads/'+foldername
     if contnum == '1':
         print '\n'
@@ -32,19 +86,18 @@ def PageScrape(pageurl):
         except:
             print "Error, make sure there is no directory with this script"
             return 0
-        for i in range(len(html)-len(search)):
-            if search == html[i:i+len(search)]:
-                imgurl = html[i+len(search):]
-                imgurl = imgurl.split('"')[0]
-                if imgurl[-4] == '.':
-                    imgname = foldername+'/'+str(imgnum)+imgurl[-4:]
-                else:
-                    imgname = foldername+'/'+str(imgnum)+imgurl[-5:]
-                f = open(imgname, 'wb')
-                f.write(urllib2.urlopen(imgurl).read())
-                f.close()
-                print '\t'+str(imgnum)+'/'+str(imgcount)+ ' completed\n'
-                imgnum += 1
+        imgnum = 1
+        for cur in fetch_ary:
+            time.sleep(6)
+            imgurl = FetchImageURL(cur)
+            orig_fname = imgurl[imgurl.rindex('/')+1:]
+            imgname = foldername+'/'+zeroPad(imgnum)+'__'+orig_fname
+            print('Preparing to write to [' +imgname+']')
+            f = open(imgname, 'wb')
+            f.write(urllib2.urlopen(imgurl).read())
+            f.close()
+            print '\t'+str(imgnum)+'/'+str(imgcount)+ ' completed\n'
+            imgnum += 1
     return 0
     
 
@@ -55,5 +108,11 @@ if use == '1':
     url = urltest
 else:
     url = raw_input("\nEnter the url: ")
+url_front = url.split('?')[0]
+url_back = url.split('?')[1]
+gid_str = url_back[url_back.find('gid='):]
+gid_str = gid_str.split('&')[0]
+final_url = url_front + '?' + gid_str + '&view=2'
+print('fetching full gallery at [' + final_url + ']\n')
 PageScrape(url)
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ WHEN YOU HAVE PYTHON INSTALLED, FOLLOW THE INSTRUCTIONS BELOW.
 
 First find a gallery on ImageFap you would like to download.
 
-Then, navigate to the page that lets you cycle through the pictures,
-such as the page at http://www.imagefap.com/photo/2123766326/?pgid=&gid=4529707&page=0
+Then, navigate to the a page in the gallery you are interested in. 
 
 Copy the entire url.
 


### PR DESCRIPTION
The 24 item limit was very constraining. I started to make a minor fix, but it ended up being a bigger problem than I thought. It required a pretty significant rewrite to work with modern ImageFap.

Two new features:
(1) Any page in the gallery can be used as the starting point (image preview pages, front page, index, etc). The script will find the gallery index and learn the location of all files.
(2) The script also places a log in with the images in case someone is curious where the dir came from later.
